### PR TITLE
Prevent browsers from autofill the honeypot input

### DIFF
--- a/src/Honeypot.php
+++ b/src/Honeypot.php
@@ -73,6 +73,8 @@ class Honeypot extends BaseControl
         $control = parent::getControl();
         $label = parent::getLabel();
 
+        $control->addAttributes(["autocomplete"=>"new-password"]);
+
         $container = Html::el('div');
         $container->id = $control->id . '-container';
         $container->class = 'wodcz-nette-forms-hp';


### PR DESCRIPTION
BC: no
This fix is based on this issue: 
https://bugs.chromium.org/p/chromium/issues/detail?id=132135

And this solution based on:
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields

TLDR: Chrome autofill even hidden inputs. 